### PR TITLE
Set `alpha` as default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IDE folders
+.idea/

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   image_tag:
     description: "Tag of image for Dataverse app and Configbaker"
     required: true
-    default: "unstable"
+    default: "alpha"
   image_dataverse:
     description: "Name of Dataverse app image (can include registry)"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   image_tag:
     description: "Tag of image for Dataverse app and Configbaker"
     required: true
-    default: "alpha"
+    default: "unstable"
   image_dataverse:
     description: "Name of Dataverse app image (can include registry)"
     required: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,18 +8,17 @@ services:
     restart: on-failure
     user: payara
     environment:
-      - DATAVERSE_DB_HOST=postgres
-      - DATAVERSE_DB_USER=${DATAVERSE_DB_USER}
-      - DATAVERSE_DB_PASSWORD=${DATAVERSE_DB_PASSWORD}
+      # Database Connection
       DATAVERSE_DB_HOST: postgres
       DATAVERSE_DB_USER: ${DATAVERSE_DB_USER}
       DATAVERSE_DB_PASSWORD: ${DATAVERSE_DB_PASSWORD}
-      JVM_ARGS: -Ddataverse.pid.providers=fake
-        -Ddataverse.pid.default-provider=fake
-        -Ddataverse.pid.fake.type=FAKE
-        -Ddataverse.pid.fake.label=FakeDOIProvider
-        -Ddataverse.pid.fake.authority=10.5072
-        -Ddataverse.pid.fake.shoulder=FK2/
+      # Simple PID Provider Setup (as necessary since Dataverse 6.2)
+      DATAVERSE_PID_PROVIDERS: fake
+      DATAVERSE_PID_DEFAULT_PROVIDER: fake
+      DATAVERSE_PID_FAKE_TYPE: FAKE
+      DATAVERSE_PID_FAKE_LABEL: Fake DOI Provider
+      DATAVERSE_PID_FAKE_AUTHORITY: 10.5072
+      DATAVERSE_PID_FAKE_SHOULDER: FK2/
     ports:
       - '8080:8080'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,15 @@ services:
       - DATAVERSE_DB_HOST=postgres
       - DATAVERSE_DB_USER=${DATAVERSE_DB_USER}
       - DATAVERSE_DB_PASSWORD=${DATAVERSE_DB_PASSWORD}
+      DATAVERSE_DB_HOST: postgres
+      DATAVERSE_DB_USER: ${DATAVERSE_DB_USER}
+      DATAVERSE_DB_PASSWORD: ${DATAVERSE_DB_PASSWORD}
+      JVM_ARGS: -Ddataverse.pid.providers=fake
+        -Ddataverse.pid.default-provider=fake
+        -Ddataverse.pid.fake.type=FAKE
+        -Ddataverse.pid.fake.label=FakeDOIProvider
+        -Ddataverse.pid.fake.authority=10.5072
+        -Ddataverse.pid.fake.shoulder=FK2/
     ports:
       - '8080:8080'
     networks:


### PR DESCRIPTION
~~Use the `alpha` tag by default to prevent errors that may occur from the `unstable` tag.~~

Closes #11 

Thanks to @pdurbin on Zulip - https://dataverse.zulipchat.com/#narrow/stream/375812-containers/topic/Dataverse.20Action.20broken/near/426731935

Edit @poikilotherm: we went with fixing the root cause instead - missing PID provider settings.