### PR TITLE
Extend compose by S3-compatible stores: `minio`, `localstack`

### DIFF
--- a/.github/workflows/scripts/initial_dataset.json
+++ b/.github/workflows/scripts/initial_dataset.json
@@ -1,0 +1,82 @@
+{
+    "datasetVersion": {
+      "license": {
+        "name": "CC0 1.0",
+        "uri": "http://creativecommons.org/publicdomain/zero/1.0"
+      },
+      "metadataBlocks": {
+        "citation": {
+          "fields": [
+            {
+              "value": "Darwin's Finches",
+              "typeClass": "primitive",
+              "multiple": false,
+              "typeName": "title"
+            },
+            {
+              "value": [
+                {
+                  "authorName": {
+                    "value": "Finch, Fiona",
+                    "typeClass": "primitive",
+                    "multiple": false,
+                    "typeName": "authorName"
+                  },
+                  "authorAffiliation": {
+                    "value": "Birds Inc.",
+                    "typeClass": "primitive",
+                    "multiple": false,
+                    "typeName": "authorAffiliation"
+                  }
+                }
+              ],
+              "typeClass": "compound",
+              "multiple": true,
+              "typeName": "author"
+            },
+            {
+              "value": [ 
+                  { "datasetContactEmail" : {
+                      "typeClass": "primitive",
+                      "multiple": false,
+                      "typeName": "datasetContactEmail",
+                      "value" : "finch@mailinator.com"
+                  },
+                  "datasetContactName" : {
+                      "typeClass": "primitive",
+                      "multiple": false,
+                      "typeName": "datasetContactName",
+                      "value": "Finch, Fiona"
+                  }
+              }],
+              "typeClass": "compound",
+              "multiple": true,
+              "typeName": "datasetContact"
+            },
+            {
+              "value": [ {
+                 "dsDescriptionValue":{
+                  "value":   "Darwin's finches (also known as the Galápagos finches) are a group of about fifteen species of passerine birds.",
+                  "multiple":false,
+                 "typeClass": "primitive",
+                 "typeName": "dsDescriptionValue"
+              }}],
+              "typeClass": "compound",
+              "multiple": true,
+              "typeName": "dsDescription"
+            },
+            {
+              "value": [
+                "Medicine, Health and Life Sciences"
+              ],
+              "typeClass": "controlledVocabulary",
+              "multiple": true,
+              "typeName": "subject"
+            }
+          ],
+          "displayName": "Citation Metadata"
+        }
+      }
+    }
+  }
+  

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -137,7 +137,7 @@ class TestNativeAPI:
             "api/admin/dataverse/test_storage_driver/storageDriver"
         )
 
-        response = requests.post(
+        response = requests.put(
             url,
             headers=self.construct_header(),
             data="LocalStack",

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -147,7 +147,9 @@ class TestNativeAPI:
         assert response.json()["status"] == "OK"
 
         # Next, test the storage driver
-        url = self.construct_url("api/dataverses/test_storage_driver/storageDriver")
+        url = self.construct_url(
+            "api/admin/dataverses/test_storage_driver/storageDriver"
+        )
         response = requests.get(url)
 
         assert response.status_code == 200, response.text

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -147,10 +147,7 @@ class TestNativeAPI:
         assert response.json()["status"] == "OK"
 
         # Next, test the storage driver
-        url = self.construct_url(
-            "api/admin/dataverses/test_storage_driver/storageDriver"
-        )
-        response = requests.get(url)
+        response = requests.get(url, headers=self.construct_header())
 
         assert response.status_code == 200, response.text
         assert response.json()["status"] == "OK"

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -106,3 +106,50 @@ class TestNativeAPI:
 
         assert response.status_code == 201, response.text
         assert response.json()["status"] == "OK"
+
+    def test_set_storage_driver(self):
+        """
+        Test case for setting the storage driver.
+
+        This test creates a new collection, sets the storage driver to LocalStack,
+        and then tests that the storage driver is set correctly.
+        """
+
+        # First create a new collection
+        url = self.construct_url("api/dataverses/root")
+        response = requests.post(
+            url=url,
+            headers=self.construct_header(),
+            json={
+                "name": "TestStorageDriver",
+                "alias": "test_storage_driver",
+                "dataverseContacts": [
+                    {"contactEmail": "burrito@burritoplace.com"},
+                ],
+                "affiliation": "Burrito Research University",
+                "description": "We do all the (burrito) science.",
+                "dataverseType": "LABORATORY",
+            },
+        )
+
+        # Next, set the storage driver to LocalStack
+        url = self.construct_url(
+            "api/admin/dataverse/test_storage_driver/storageDriver"
+        )
+
+        response = requests.post(
+            url,
+            headers=self.construct_header(),
+            data="LocalStack",
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "OK"
+
+        # Next, test the storage driver
+        url = self.construct_url("api/dataverses/test_storage_driver/storageDriver")
+        response = requests.get(url)
+
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "OK"
+        assert response.json()["data"]["message"] == "localstack1"

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -215,6 +215,8 @@ class TestNativeAPI:
 
         response = requests.get(url, headers=self.construct_header())
 
+        print(response.json())
+
         assert response.status_code == 200, response.text
         assert response.json()["status"] == "OK"
 

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -182,7 +182,7 @@ class TestNativeAPI:
 
         # Next create a new dataset
         url = self.construct_url("api/dataverses/test_direct_upload_ticket/datasets")
-        with open("initial_dataset.json", "r") as f:
+        with open(".github/workflows/scripts/initial_dataset.json", "r") as f:
             initial_dataset = json.load(f)
 
         response = requests.post(

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -180,6 +180,20 @@ class TestNativeAPI:
             },
         )
 
+        # Next, set the storage driver to LocalStack
+        url = self.construct_url(
+            "api/admin/dataverse/test_direct_upload_ticket/storageDriver"
+        )
+
+        response = requests.put(
+            url,
+            headers=self.construct_header(),
+            data="LocalStack",
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "OK"
+
         # Next create a new dataset
         url = self.construct_url("api/dataverses/test_direct_upload_ticket/datasets")
         with open(".github/workflows/scripts/initial_dataset.json", "r") as f:
@@ -192,19 +206,14 @@ class TestNativeAPI:
         )
 
         response.raise_for_status()
-
         pid = response.json()["data"]["persistentId"]
 
-        # Next, set the storage driver to LocalStack
+        # Next, get the upload URLs
         url = self.construct_url(
             f"/api/datasets/:persistentId/uploadurls/?persistentId={pid}&size=72428800"
         )
 
-        response = requests.get(
-            url,
-            headers=self.construct_header(),
-            data="LocalStack",
-        )
+        response = requests.get(url, headers=self.construct_header())
 
         assert response.status_code == 200, response.text
         assert response.json()["status"] == "OK"

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -215,8 +215,6 @@ class TestNativeAPI:
 
         response = requests.get(url, headers=self.construct_header())
 
-        print(response.json())
-
         assert response.status_code == 200, response.text
         assert response.json()["status"] == "OK"
 

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -200,7 +200,7 @@ class TestNativeAPI:
             f"/api/datasets/:persistentId/uploadurls/?persistentId={pid}&size=72428800"
         )
 
-        response = requests.put(
+        response = requests.get(
             url,
             headers=self.construct_header(),
             data="LocalStack",

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -210,7 +210,7 @@ class TestNativeAPI:
 
         # Next, get the upload URLs
         url = self.construct_url(
-            f"/api/datasets/:persistentId/uploadurls/?persistentId={pid}&size=7242880"
+            f"/api/datasets/:persistentId/uploadurls/?persistentId={pid}&size=10242880"
         )
 
         response = requests.get(url, headers=self.construct_header())

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -210,7 +210,7 @@ class TestNativeAPI:
 
         # Next, get the upload URLs
         url = self.construct_url(
-            f"/api/datasets/:persistentId/uploadurls/?persistentId={pid}&size=10242880"
+            f"/api/datasets/:persistentId/uploadurls/?persistentId={pid}&size=2073741824"
         )
 
         response = requests.get(url, headers=self.construct_header())

--- a/.github/workflows/scripts/test_dataverse.py
+++ b/.github/workflows/scripts/test_dataverse.py
@@ -210,7 +210,7 @@ class TestNativeAPI:
 
         # Next, get the upload URLs
         url = self.construct_url(
-            f"/api/datasets/:persistentId/uploadurls/?persistentId={pid}&size=72428800"
+            f"/api/datasets/:persistentId/uploadurls/?persistentId={pid}&size=7242880"
         )
 
         response = requests.get(url, headers=self.construct_header())

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,8 +8,8 @@ jobs:
     env:
       PORT: 8080
     steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v4"
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
       - name: Run Dataverse Action
         id: dataverse
         uses: ./
@@ -18,10 +18,11 @@ jobs:
           jvm_options: |
             dataverse.api.signature-secret=eikaizieb2Oghaex
             dataverse.pid.datacite.rest-api-url=https://api.datacite.org
+            dataverse.files.localstack1.min-part-size=7242880
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.11"
+          python-version: '3.11'
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -15,6 +15,8 @@ jobs:
         uses: ./
         with:
           postgresql_version: 15
+          jvm_options: |
+            dataverse.files.localstack1.min-part-size=7242880
       - name: Setup Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -15,10 +15,6 @@ jobs:
         uses: ./
         with:
           postgresql_version: 15
-          jvm_options: |
-            dataverse.api.signature-secret=eikaizieb2Oghaex
-            dataverse.pid.datacite.rest-api-url=https://api.datacite.org
-            dataverse.files.localstack1.min-part-size=7242880
       - name: Setup Python
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -15,8 +15,6 @@ jobs:
         uses: ./
         with:
           postgresql_version: 15
-          jvm_options: |
-            dataverse.files.localstack1.min-part-size=7242880
       - name: Setup Python
         uses: actions/setup-python@v3
         with:

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         else
           echo "POSTGRES_VERSION=$PG_VERSION" | tee -a "${GITHUB_ENV}" 
         fi
-        
+
         # Get Solr version from action config or application image metadata, fail otherwise
         SOLR_VERSION=${{ inputs.solr_version }}
         SOLR_VERSION="${SOLR_VERSION:-$(docker inspect -f '{{ index .Config.Labels "org.dataverse.deps.solr.version"}}' '${{ inputs.image_dataverse }}:${{ inputs.image_tag }}')}"
@@ -61,18 +61,19 @@ runs:
         else
           echo "SOLR_VERSION=$SOLR_VERSION" | tee -a "${GITHUB_ENV}" 
         fi
-        
+
         echo "CONFIGBAKER_IMAGE=${{ inputs.image_configbaker }}:${{ inputs.image_tag }}" | tee -a "${GITHUB_ENV}"
         echo "DATAVERSE_IMAGE=${{ inputs.image_dataverse }}:${{ inputs.image_tag }}" | tee -a "${GITHUB_ENV}"
         echo "DATAVERSE_DB_USER=dataverse" | tee -a "${GITHUB_ENV}"
         echo "DATAVERSE_DB_PASSWORD=secret" | tee -a "${GITHUB_ENV}"
-        
+
         # We use the MicroProfile Config Source trick of reading properties from a directory.
         # See also https://docs.payara.fish/community/docs/Technical%20Documentation/MicroProfile/Config/Directory.html
         echo "CONFIG_DIR=${RUNNER_TEMP}/dv/conf" | tee -a "${GITHUB_ENV}"
         mkdir -p "${RUNNER_TEMP}/dv/conf"
         while IFS= read -r line; do
           FILENAME="${RUNNER_TEMP}/dv/conf/$(echo "$line" | cut -f1 -d=)"
+          echo "Adding $line to $FILENAME"
           echo "$line" | cut -f2- -d= > "$FILENAME"
         done < <(printf '%s' "${{ inputs.jvm_options }}")
     - name: "Start Dataverse service in background"
@@ -90,17 +91,17 @@ runs:
         echo "::group::🤖 Bootstrap Dataverse service"
         mkdir -p "${RUNNER_TEMP}/dv"
         touch "${RUNNER_TEMP}/dv/bootstrap.exposed.env"
-        
+
         docker run -i --network apitest_dataverse \
           -v "${RUNNER_TEMP}/dv/bootstrap.exposed.env:/.env" \
           "${CONFIGBAKER_IMAGE}" bootstrap.sh -e /.env dev
-        
+
         # Expose outputs
         grep "API_TOKEN" "${RUNNER_TEMP}/dv/bootstrap.exposed.env" >> "$GITHUB_OUTPUT"
         echo "base_url=http://localhost:8080/" >> "$GITHUB_OUTPUT"
-        
+
         # Expose version
         version=$(curl -s 'http://localhost:8080/api/info/version' | jq -r '.data.version')
         echo "dv_version=$version" >>"$GITHUB_OUTPUT"
-        
+
         echo "::endgroup::"

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         else
           echo "POSTGRES_VERSION=$PG_VERSION" | tee -a "${GITHUB_ENV}" 
         fi
-
+        
         # Get Solr version from action config or application image metadata, fail otherwise
         SOLR_VERSION=${{ inputs.solr_version }}
         SOLR_VERSION="${SOLR_VERSION:-$(docker inspect -f '{{ index .Config.Labels "org.dataverse.deps.solr.version"}}' '${{ inputs.image_dataverse }}:${{ inputs.image_tag }}')}"
@@ -61,19 +61,18 @@ runs:
         else
           echo "SOLR_VERSION=$SOLR_VERSION" | tee -a "${GITHUB_ENV}" 
         fi
-
+        
         echo "CONFIGBAKER_IMAGE=${{ inputs.image_configbaker }}:${{ inputs.image_tag }}" | tee -a "${GITHUB_ENV}"
         echo "DATAVERSE_IMAGE=${{ inputs.image_dataverse }}:${{ inputs.image_tag }}" | tee -a "${GITHUB_ENV}"
         echo "DATAVERSE_DB_USER=dataverse" | tee -a "${GITHUB_ENV}"
         echo "DATAVERSE_DB_PASSWORD=secret" | tee -a "${GITHUB_ENV}"
-
+        
         # We use the MicroProfile Config Source trick of reading properties from a directory.
         # See also https://docs.payara.fish/community/docs/Technical%20Documentation/MicroProfile/Config/Directory.html
         echo "CONFIG_DIR=${RUNNER_TEMP}/dv/conf" | tee -a "${GITHUB_ENV}"
         mkdir -p "${RUNNER_TEMP}/dv/conf"
         while IFS= read -r line; do
           FILENAME="${RUNNER_TEMP}/dv/conf/$(echo "$line" | cut -f1 -d=)"
-          echo "Adding $line to $FILENAME"
           echo "$line" | cut -f2- -d= > "$FILENAME"
         done < <(printf '%s' "${{ inputs.jvm_options }}")
     - name: "Start Dataverse service in background"
@@ -91,17 +90,17 @@ runs:
         echo "::group::🤖 Bootstrap Dataverse service"
         mkdir -p "${RUNNER_TEMP}/dv"
         touch "${RUNNER_TEMP}/dv/bootstrap.exposed.env"
-
+        
         docker run -i --network apitest_dataverse \
           -v "${RUNNER_TEMP}/dv/bootstrap.exposed.env:/.env" \
           "${CONFIGBAKER_IMAGE}" bootstrap.sh -e /.env dev
-
+        
         # Expose outputs
         grep "API_TOKEN" "${RUNNER_TEMP}/dv/bootstrap.exposed.env" >> "$GITHUB_OUTPUT"
         echo "base_url=http://localhost:8080/" >> "$GITHUB_OUTPUT"
-
+        
         # Expose version
         version=$(curl -s 'http://localhost:8080/api/info/version' | jq -r '.data.version')
         echo "dv_version=$version" >>"$GITHUB_OUTPUT"
-
+        
         echo "::endgroup::"

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ outputs:
   dv_version:
     description: "Dataverse version"
     value: ${{ steps.bootstrap.outputs.dv_version }}
+  localstack_min_part_size:
+    description: "Localstack min part size to be re-used in tests"
+    value: "7242880"
 runs:
   using: "composite"
   steps:
@@ -52,7 +55,7 @@ runs:
         else
           echo "POSTGRES_VERSION=$PG_VERSION" | tee -a "${GITHUB_ENV}" 
         fi
-        
+
         # Get Solr version from action config or application image metadata, fail otherwise
         SOLR_VERSION=${{ inputs.solr_version }}
         SOLR_VERSION="${SOLR_VERSION:-$(docker inspect -f '{{ index .Config.Labels "org.dataverse.deps.solr.version"}}' '${{ inputs.image_dataverse }}:${{ inputs.image_tag }}')}"
@@ -61,12 +64,12 @@ runs:
         else
           echo "SOLR_VERSION=$SOLR_VERSION" | tee -a "${GITHUB_ENV}" 
         fi
-        
+
         echo "CONFIGBAKER_IMAGE=${{ inputs.image_configbaker }}:${{ inputs.image_tag }}" | tee -a "${GITHUB_ENV}"
         echo "DATAVERSE_IMAGE=${{ inputs.image_dataverse }}:${{ inputs.image_tag }}" | tee -a "${GITHUB_ENV}"
         echo "DATAVERSE_DB_USER=dataverse" | tee -a "${GITHUB_ENV}"
         echo "DATAVERSE_DB_PASSWORD=secret" | tee -a "${GITHUB_ENV}"
-        
+
         # We use the MicroProfile Config Source trick of reading properties from a directory.
         # See also https://docs.payara.fish/community/docs/Technical%20Documentation/MicroProfile/Config/Directory.html
         echo "CONFIG_DIR=${RUNNER_TEMP}/dv/conf" | tee -a "${GITHUB_ENV}"
@@ -90,17 +93,17 @@ runs:
         echo "::group::🤖 Bootstrap Dataverse service"
         mkdir -p "${RUNNER_TEMP}/dv"
         touch "${RUNNER_TEMP}/dv/bootstrap.exposed.env"
-        
+
         docker run -i --network apitest_dataverse \
           -v "${RUNNER_TEMP}/dv/bootstrap.exposed.env:/.env" \
           "${CONFIGBAKER_IMAGE}" bootstrap.sh -e /.env dev
-        
+
         # Expose outputs
         grep "API_TOKEN" "${RUNNER_TEMP}/dv/bootstrap.exposed.env" >> "$GITHUB_OUTPUT"
         echo "base_url=http://localhost:8080/" >> "$GITHUB_OUTPUT"
-        
+
         # Expose version
         version=$(curl -s 'http://localhost:8080/api/info/version' | jq -r '.data.version')
         echo "dv_version=$version" >>"$GITHUB_OUTPUT"
-        
+
         echo "::endgroup::"

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ outputs:
     value: ${{ steps.bootstrap.outputs.dv_version }}
   localstack_min_part_size:
     description: "Localstack min part size to be re-used in tests"
-    value: "7242880"
+    value: "1073741824"
 runs:
   using: "composite"
   steps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,30 @@ services:
       DATAVERSE_PID_FAKE_LABEL: Fake DOI Provider
       DATAVERSE_PID_FAKE_AUTHORITY: 10.5072
       DATAVERSE_PID_FAKE_SHOULDER: FK2/
+      JVM_ARGS: -Ddataverse.files.storage-driver-id=file1
+        -Ddataverse.files.file1.type=file
+        -Ddataverse.files.file1.label=Filesystem
+        -Ddataverse.files.file1.directory=${STORAGE_DIR}/store
+        -Ddataverse.files.localstack1.type=s3
+        -Ddataverse.files.localstack1.label=LocalStack
+        -Ddataverse.files.localstack1.custom-endpoint-url=http://localstack:4566
+        -Ddataverse.files.localstack1.custom-endpoint-region=us-east-2
+        -Ddataverse.files.localstack1.bucket-name=mybucket
+        -Ddataverse.files.localstack1.path-style-access=true
+        -Ddataverse.files.localstack1.upload-redirect=true
+        -Ddataverse.files.localstack1.download-redirect=true
+        -Ddataverse.files.localstack1.access-key=default
+        -Ddataverse.files.localstack1.secret-key=default
+        -Ddataverse.files.minio1.type=s3
+        -Ddataverse.files.minio1.label=MinIO
+        -Ddataverse.files.minio1.custom-endpoint-url=http://minio:9000
+        -Ddataverse.files.minio1.custom-endpoint-region=us-east-1
+        -Ddataverse.files.minio1.bucket-name=mybucket
+        -Ddataverse.files.minio1.path-style-access=true
+        -Ddataverse.files.minio1.upload-redirect=false
+        -Ddataverse.files.minio1.download-redirect=false
+        -Ddataverse.files.minio1.access-key=4cc355_k3y
+        -Ddataverse.files.minio1.secret-key=s3cr3t_4cc355_k3y
     ports:
       - '8080:8080'
     networks:
@@ -110,6 +134,41 @@ services:
       - dataverse
     tmpfs:
       - /mail:mode=770,size=128M,uid=1000,gid=1000
+
+  localstack:
+    container_name: 'localstack'
+    hostname: 'localstack'
+    image: localstack/localstack:2.3.2
+    restart: on-failure
+    ports:
+      - '127.0.0.1:4566:4566'
+    environment:
+      - DEBUG=${DEBUG-}
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - HOSTNAME_EXTERNAL=localstack
+    networks:
+      - dataverse
+    volumes:
+      - ./conf/localstack:/etc/localstack/init/ready.d
+    tmpfs:
+      - /localstack:mode=770,size=128M,uid=1000,gid=1000
+
+  minio:
+    container_name: 'minio'
+    hostname: 'minio'
+    image: minio/minio
+    restart: on-failure
+    ports:
+      - '9000:9000'
+      - '9001:9001'
+    networks:
+      - dataverse
+    volumes:
+      - ./docker-dev-volumes/minio_storage:/data
+    environment:
+      MINIO_ROOT_USER: 4cc355_k3y
+      MINIO_ROOT_PASSWORD: s3cr3t_4cc355_k3y
+    command: server /data
 
 networks:
   dataverse:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
   localstack:
     container_name: 'localstack'
     hostname: 'localstack'
-    image: localstack/localstack:2.3.2
+    image: localstack/localstack:4.3.0
     restart: on-failure
     ports:
       - '127.0.0.1:4566:4566'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
+        -Ddataverse.files.localstack1.min-part-size=7242880
     ports:
       - '8080:8080'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
-        -Ddataverse.files.localstack1.min-part-size=9242880
     ports:
       - '8080:8080'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,17 +29,7 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
-        -Ddataverse.files.localstack1.min-part-size=7242880
-        -Ddataverse.files.minio1.type=s3
-        -Ddataverse.files.minio1.label=MinIO
-        -Ddataverse.files.minio1.custom-endpoint-url=http://minio:9000
-        -Ddataverse.files.minio1.custom-endpoint-region=us-east-1
-        -Ddataverse.files.minio1.bucket-name=mybucket
-        -Ddataverse.files.minio1.path-style-access=true
-        -Ddataverse.files.minio1.upload-redirect=false
-        -Ddataverse.files.minio1.download-redirect=false
-        -Ddataverse.files.minio1.access-key=4cc355_k3y
-        -Ddataverse.files.minio1.secret-key=s3cr3t_4cc355_k3y
+        -Ddataverse.files.localstack1.min-part-size=9242880
     ports:
       - '8080:8080'
     networks:
@@ -149,23 +139,6 @@ services:
       - ./conf/localstack:/etc/localstack/init/ready.d
     tmpfs:
       - /localstack:mode=770,size=128M,uid=1000,gid=1000
-
-  minio:
-    container_name: 'minio'
-    hostname: 'minio'
-    image: minio/minio
-    restart: on-failure
-    ports:
-      - '9000:9000'
-      - '9001:9001'
-    networks:
-      - dataverse
-    volumes:
-      - ./docker-dev-volumes/minio_storage:/data
-    environment:
-      MINIO_ROOT_USER: 4cc355_k3y
-      MINIO_ROOT_PASSWORD: s3cr3t_4cc355_k3y
-    command: server /data
 
 networks:
   dataverse:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
-        -Ddataverse.files.localstack1.min-part-size=1073741824
+        -Ddataverse.files.localstack1.min-part-size=52428800
     ports:
       - '8080:8080'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
+        -Ddataverse.files.localstack1.min-part-size=1073741824
     ports:
       - '8080:8080'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
-        -Ddataverse.files.localstack1.min-part-size=52428800
+        -Ddataverse.files.localstack1.min-part-size=7242880
     ports:
       - '8080:8080'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,6 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
-        -Ddataverse.files.localstack1.min-part-size=7242880
     ports:
       - '8080:8080'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,9 @@ services:
       DATAVERSE_PID_FAKE_LABEL: Fake DOI Provider
       DATAVERSE_PID_FAKE_AUTHORITY: 10.5072
       DATAVERSE_PID_FAKE_SHOULDER: FK2/
-      JVM_ARGS: -Ddataverse.files.localstack1.type=s3
+      JVM_ARGS: -Ddataverse.files.file1.label=Filesystem
+        -Ddataverse.files.file1.directory=${STORAGE_DIR}/store
+        -Ddataverse.files.localstack1.type=s3
         -Ddataverse.files.localstack1.label=LocalStack
         -Ddataverse.files.localstack1.custom-endpoint-url=http://localstack:4566
         -Ddataverse.files.localstack1.custom-endpoint-region=us-east-2
@@ -29,6 +31,7 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
+        -Ddataverse.files.localstack1.min-part-size=7242880
     ports:
       - '8080:8080'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,7 @@ services:
       DATAVERSE_PID_FAKE_LABEL: Fake DOI Provider
       DATAVERSE_PID_FAKE_AUTHORITY: 10.5072
       DATAVERSE_PID_FAKE_SHOULDER: FK2/
-      JVM_ARGS: -Ddataverse.files.storage-driver-id=file1
-        -Ddataverse.files.file1.type=file
-        -Ddataverse.files.file1.label=Filesystem
-        -Ddataverse.files.file1.directory=${STORAGE_DIR}/store
-        -Ddataverse.files.localstack1.type=s3
+      JVM_ARGS: -Ddataverse.files.localstack1.type=s3
         -Ddataverse.files.localstack1.label=LocalStack
         -Ddataverse.files.localstack1.custom-endpoint-url=http://localstack:4566
         -Ddataverse.files.localstack1.custom-endpoint-region=us-east-2
@@ -33,6 +29,7 @@ services:
         -Ddataverse.files.localstack1.download-redirect=true
         -Ddataverse.files.localstack1.access-key=default
         -Ddataverse.files.localstack1.secret-key=default
+        -Ddataverse.files.localstack1.min-part-size=7242880
         -Ddataverse.files.minio1.type=s3
         -Ddataverse.files.minio1.label=MinIO
         -Ddataverse.files.minio1.custom-endpoint-url=http://minio:9000


### PR DESCRIPTION
This PR extends the compose file to include both S3-compatible services, `minio` and `localstack`. These services are essential for testing the direct upload feature, as the current action does not include them. The admin endpoint for setting storage drivers can be utilized within the CI of libraries to set a collection's driver, so the action simply needs to add these services.

Additionally, this PR introduces tests to ensure that the services are correctly configured. This is done by creating a collection, setting the storage driver to `LocalStack`, and verifying that the configured driver matches `localstack1`.

* Closes #14 